### PR TITLE
Give options for Gaia catalog, default to DR3

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Code for localizing variable star signatures in TESS Photometry.
 
 The primary use of this package is to identify the location on the TPF where sources of variablity found in the aperture originate. The user only needs to provide a list of frequencies found in the aperture that belong to the same source and the number of principal components needed to be removed from the light curve to ensure it is free of systematic trends. A more detailed usage example can be found in the examples folder.
 
+See the paper describing the methodology behind this software [on ADS](https://ui.adsabs.harvard.edu/abs/2022arXiv220406020H/abstract).
+
 ## Installation 
 
 To install use 

--- a/TESS_Localize/TESS_Localize.py
+++ b/TESS_Localize/TESS_Localize.py
@@ -217,13 +217,15 @@ class Localize:
         Result parameters of the fit. Use report_fit(self.report) to view.
     self.maxsignal_aperture
         Aperture mask for the pixel with the greatest SNR
-    
-    
+    self.gaia_catalog
+        Name of the Gaia catalog to query for source locations on Vizier. 
+        Defaults to Gaia DR3.
     """
     
     def __init__(self, targetpixelfile, gaia=True, magnitude_limit=18, 
                  frequencies=[], frequnit=u.uHz, principal_components = 'auto', 
-                 aperture=None, method = 'PRF', sigma=None, mask=None, **kwargs):
+                 aperture=None, method = 'PRF', sigma=None, mask=None, 
+                 gaia_catalog='I/355/gaiadr3', **kwargs):
         
         self.tpf = targetpixelfile
         self.method = method
@@ -550,9 +552,9 @@ class Localize:
             from astroquery.vizier import Vizier
             Vizier.ROW_LIMIT = -1
             try:
-                result = Vizier.query_region(c1, catalog=["I/345/gaia2"],radius=Angle(np.max(self.tpf.shape[1:]) * pix_scale, "arcsec"))
+                result = Vizier.query_region(c1, catalog=[gaia_catalog],radius=Angle(np.max(self.tpf.shape[1:]) * pix_scale, "arcsec"))
             except:
-                result = Vizier.query_region(c1, catalog=["I/345/gaia2"],radius=Angle(np.max(self.tpf.shape[1:]) * pix_scale, "arcsec"), cache=False)
+                result = Vizier.query_region(c1, catalog=[gaia_catalog],radius=Angle(np.max(self.tpf.shape[1:]) * pix_scale, "arcsec"), cache=False)
             
 
             no_targets_found_message = ValueError('Either no sources were found in the query region '
@@ -562,7 +564,7 @@ class Localize:
                 raise no_targets_found_message
             elif len(result) == 0:
                 raise too_few_found_message
-            result = result["I/345/gaia2"].to_pandas()
+            result = result[gaia_catalog].to_pandas()
 
             result = result[result.Gmag < magnitude_limit]
             if len(result) == 0:

--- a/TESS_Localize/TESS_Localize.py
+++ b/TESS_Localize/TESS_Localize.py
@@ -746,6 +746,7 @@ class Localize:
         self.location_skycoord = self.tpf.wcs.all_pix2world([self.location], 0)[0]
         self.heatmap = self.heats.sum(axis=0).reshape(self.aperture.shape[0],self.aperture.shape[1]) / np.sqrt((self.heats_error**2).sum(axis=0)).reshape(self.aperture.shape[0],self.aperture.shape[1])
         self.maxsignal_aperture = self.heatmap == np.nanmax(self.heatmap)
+        self.error_model = fh.error_model
         self.result = fh.result
         
         


### PR DESCRIPTION
Updated so Gaia DR3 used as default source catalog, but with option to specify a different catalog.  Had to update the proper motion propagation too, since different Gaia data releases have different reference epochs.