### PR TITLE
Fix distance column (was giving distance squared)

### DIFF
--- a/TESS_Localize/TESS_Localize.py
+++ b/TESS_Localize/TESS_Localize.py
@@ -724,7 +724,7 @@ class Localize:
                     starlist = None
 
                 else:
-                    distances = np.square(self.x-gaia_data['x'])+np.square(self.y-gaia_data['y'])
+                    distances = np.sqrt(np.square(self.x-gaia_data['x'])+np.square(self.y-gaia_data['y']))
                     #closest_star_mask = np.where(np.square(self.x-gaia_data['x'])+np.square(self.y-gaia_data['y'])==(np.square(self.x-gaia_data['x'])+np.square(self.y-gaia_data['y'])).min())
                     stars = dict(ra = np.asarray(gaia_data['ra']),
                                  dec = np.asarray(gaia_data['dec']),


### PR DESCRIPTION
Hi Michael, I noticed that the distance column in the results table is actually displaying distance squared. Made the minor fix here. Could you roll this into a new pip-installable version please?